### PR TITLE
feat(memo): メモ削除機能の実装

### DIFF
--- a/app/src/main/java/com/example/simplememoapp_android/data/local/dao/MemoDao.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/data/local/dao/MemoDao.kt
@@ -1,6 +1,7 @@
 package com.example.simplememoapp_android.data.local.dao
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import com.example.simplememoapp_android.data.model.Memo
@@ -13,4 +14,7 @@ interface MemoDao {
 
     @Insert
     suspend fun insertMemo(memo: Memo)
+
+    @Delete
+    suspend fun deleteMemo(memo: Memo)
 }

--- a/app/src/main/java/com/example/simplememoapp_android/data/repository/MemoRepository.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/data/repository/MemoRepository.kt
@@ -15,10 +15,11 @@ class MemoRepository(private val memoDao: MemoDao) {
      * @return 挿入処理の結果。成功時はResult.success(Unit)、失敗時はResult.failure(Exception)
      */
     suspend fun insert(text: String): Result<Unit> {
-        return try {val newMemo = Memo(
-            text = text,
-            createdAt = LocalDateTime.now()
-        )
+        return try {
+            val newMemo = Memo(
+                text = text,
+                createdAt = LocalDateTime.now()
+            )
             memoDao.insertMemo(newMemo)
             Result.success(Unit)
         } catch (e: Exception) {
@@ -26,5 +27,21 @@ class MemoRepository(private val memoDao: MemoDao) {
             Result.failure(e)
         }
     }
-}
     
+    /**
+     * 指定されたメモをデータベースから削除します。
+     * ViewModelからの要求をDAOに仲介します。
+     * @param memo 削除対象のMemoオブジェクト。
+     * @return 削除処理の結果。成功時はResult.success(Unit)、失敗時はResult.failure(Exception)
+     */
+    suspend fun delete(memo: Memo): Result<Unit> { // 戻り値を Result<Unit> に変更
+        return try { // try-catch の結果を return する
+            memoDao.deleteMemo(memo)
+            Result.success(Unit) // 成功時は Result.success
+        } catch (e: Exception) {
+            // エラーハンドリングは呼び出し元に委ねるため、Result.failure で返す
+            // println("メモの削除に失敗しました: ${e.message}") // ← この行は削除またはコメントアウト
+            Result.failure(e) // 失敗時は Result.failure
+        }
+    }
+}

--- a/app/src/main/java/com/example/simplememoapp_android/ui/viewmodel/MemoViewModel.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/ui/viewmodel/MemoViewModel.kt
@@ -44,4 +44,20 @@ class MemoViewModel(private val repository: MemoRepository) : ViewModel() {
                 }
         }
     }
+
+    /**
+     * 指定されたメモを削除するようRepositoryに依頼します。
+     * DB操作はUIスレッドをブロックしないよう、viewModelScopeで実行します。
+     * @param memo 削除対象のMemoオブジェクト。
+     */
+    fun deleteMemo(memo: Memo) { 
+        viewModelScope.launch {
+            repository.delete(memo)
+                .onFailure { e -> // ← 失敗時の処理を追加
+                    // 失敗時はログに出力する（エラーUIへの反映は今後の課題）
+                    println("メモの削除に失敗しました: ${e.message}")
+                }
+        }
+    }
+    
 }


### PR DESCRIPTION
本文:このコミットは、メモを削除する機能を追加します。

主な変更点:
•UIの各メモ項目に削除ボタン（ゴミ箱アイコン）を追加しました。
•データベース操作のため、MemoDao に deleteMemo 関数を実装しました。
•削除ロジックと結果を処理するため、MemoRepository に delete 関数を追加しました。 
•UIからの削除処理の起動と失敗時の対応のため、MemoViewModel に deleteMemo 関数を追加しました。 
•削除アクションをサポートし、必要なコールバックを渡すため、コンポーザブル関数 MemoScreen、MemoItem、MemoListSection を更新しました。
 •新しい削除機能を反映するため、更新された MemoItem と MemoListSection のプレビューを追加しました。