### PR TITLE
UI: メモ操作失敗時にSnackbarでエラー表示

### DIFF
--- a/app/src/main/java/com/example/simplememoapp_android/ui/screen/MemoScreen.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/ui/screen/MemoScreen.kt
@@ -19,10 +19,13 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -40,6 +43,8 @@ import com.example.simplememoapp_android.MemoApplication
 import com.example.simplememoapp_android.ui.state.MemoUiState
 import com.example.simplememoapp_android.ui.viewmodel.MemoViewModel
 import com.example.simplememoapp_android.ui.viewmodel.MemoViewModelFactory
+import com.example.simplememoapp_android.ui.viewmodel.UiEvent
+import kotlinx.coroutines.flow.collectLatest
 
 @OptIn(ExperimentalMaterial3Api::class) // ← Scaffoldなどで必要なら追加
 @Composable
@@ -56,7 +61,30 @@ fun MemoScreen() {
 
     val uiState by viewModel.uiState.collectAsState()
 
+    /**
+     * Snackbarの状態を管理し、表示を制御するための司令塔。
+     */
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    /**
+     * ViewModelからの単発イベントを監視し、UIに反映させる。
+     * この画面が初めて表示された時に一度だけ実行され、イベントを待ち受ける。
+     */
+    LaunchedEffect(Unit) {
+        viewModel.eventFlow.collectLatest { event ->
+            when (event) {
+                is UiEvent.ShowSnackbar -> {
+                    snackbarHostState.showSnackbar(
+                        message = event.message
+                    )
+                }
+            }
+        }
+    }
+
+
     Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         topBar = {
             TopAppBar(title = { Text("爆速メモアプリ") })
         }

--- a/app/src/main/java/com/example/simplememoapp_android/ui/viewmodel/MemoViewModel.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/ui/viewmodel/MemoViewModel.kt
@@ -5,11 +5,21 @@ import androidx.lifecycle.viewModelScope
 import com.example.simplememoapp_android.data.model.Memo
 import com.example.simplememoapp_android.data.repository.MemoRepository
 import com.example.simplememoapp_android.ui.state.MemoUiState
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+
+/**
+ * UIに一度だけ通知したいイベントを定義するインターフェース。
+ */
+sealed interface UiEvent {
+    data class ShowSnackbar(val message: String) : UiEvent
+    // 今後「画面遷移しろ」などのイベントもここに追加できる
+}
 
 class MemoViewModel(private val repository: MemoRepository) : ViewModel() {
 
@@ -29,6 +39,13 @@ class MemoViewModel(private val repository: MemoRepository) : ViewModel() {
         )
 
     /**
+     * UIイベントを通知するための専用パイプライン。
+     */
+    private val _eventFlow = MutableSharedFlow<UiEvent>()
+    val eventFlow = _eventFlow.asSharedFlow()
+
+
+    /**
      * 新しいメモを追加します。
      * Repositoryからの処理結果（成功・失敗）を受け取り、UIに反映します。
      * @param text 追加するメモの本文。
@@ -39,7 +56,8 @@ class MemoViewModel(private val repository: MemoRepository) : ViewModel() {
         viewModelScope.launch {
             repository.insert(text.trim())
                 .onFailure { e ->
-                    // 失敗時はログに出力する（エラーUIへの反映は今後の課題）
+                    // ▼▼▼ 失敗時にイベントを発行するよう変更 ▼▼▼
+                    _eventFlow.emit(UiEvent.ShowSnackbar("メモの保存に失敗しました"))
                     println("メモの挿入に失敗しました: ${e.message}")
                 }
         }
@@ -54,7 +72,8 @@ class MemoViewModel(private val repository: MemoRepository) : ViewModel() {
         viewModelScope.launch {
             repository.delete(memo)
                 .onFailure { e -> // ← 失敗時の処理を追加
-                    // 失敗時はログに出力する（エラーUIへの反映は今後の課題）
+                    // ▼▼▼ 失敗時にイベントを発行するよう変更 ▼▼▼
+                    _eventFlow.emit(UiEvent.ShowSnackbar("メモの削除に失敗しました"))
                     println("メモの削除に失敗しました: ${e.message}")
                 }
         }


### PR DESCRIPTION
主な変更：

•メモの保存・削除に失敗した際、Snackbarでエラーメッセージを表示するようUIを改善しました。
 •MemoScreen.kt: Snackbar表示機能と、ViewModelからのイベント監視処理を追加。
 •MemoViewModel.kt: Snackbar表示のためのイベント通知機構 (UiEvent, SharedFlow) を導入し、エラー発生時に通知するよう変更。