### PR TITLE
feat: Implement server synchronization for memos

### DIFF
--- a/app/src/main/java/com/example/simplememoapp_android/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/data/local/AppDatabase.kt
@@ -9,7 +9,7 @@ import com.example.simplememoapp_android.data.local.dao.MemoDao
 import com.example.simplememoapp_android.data.model.Memo
 import java.time.LocalDateTime
 
-@Database(entities = [Memo::class], version = 2, exportSchema = false)
+@Database(entities = [Memo::class], version = 3, exportSchema = false) // ★ versionを3に更新
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun memoDao(): MemoDao
@@ -45,6 +45,12 @@ abstract class AppDatabase : RoomDatabase() {
                 database.execSQL("ALTER TABLE memos_new RENAME TO memos")
             }
         }
-        // ★★★ ここまで修正 ★★★
+
+        val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE memos ADD COLUMN userId TEXT NOT NULL DEFAULT ''")
+                database.execSQL("ALTER TABLE memos ADD COLUMN serverId TEXT NOT NULL DEFAULT ''") // ★ NOT NULLに変更
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/simplememoapp_android/data/local/dao/MemoDao.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/data/local/dao/MemoDao.kt
@@ -3,21 +3,25 @@ package com.example.simplememoapp_android.data.local.dao
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import com.example.simplememoapp_android.data.model.Memo
 import kotlinx.coroutines.flow.Flow
-
+// data/local/dao/MemoDao.kt (修正後)
 @Dao
 interface MemoDao {
-    @Query("SELECT * FROM memos ORDER BY updatedAt DESC") // ソート順を更新日時に変更
-    fun getAllMemos(): Flow<List<Memo>>
+    @Query("SELECT * FROM memos WHERE userId = :userId ORDER BY updatedAt DESC")
+    fun getMemosByUserId(userId: String): Flow<List<Memo>>
 
-    @Query("SELECT * FROM memos WHERE id = :id")
-    fun getMemoById(id: Long): Flow<Memo>
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(memos: List<Memo>)
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertMemo(memo: Memo)
+
+    @Query("DELETE FROM memos WHERE userId = :userId")
+    suspend fun deleteAllByUserId(userId: String)
 
     @Update
     suspend fun updateMemo(memo: Memo)

--- a/app/src/main/java/com/example/simplememoapp_android/data/model/Memo.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/data/model/Memo.kt
@@ -3,13 +3,15 @@ package com.example.simplememoapp_android.data.model
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import java.time.LocalDateTime
-
+// data/model/Memo.kt (修正後)
 @Entity(tableName = "memos")
 data class Memo(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,
-    val title: String, // タイトル（Not Null）
+    val serverId: String,
+    val userId: String,
+    val title: String,
     val content: String,
     val createdAt: LocalDateTime,
-    val updatedAt: LocalDateTime // 更新日時
+    val updatedAt: LocalDateTime
 )

--- a/app/src/main/java/com/example/simplememoapp_android/data/repository/MemoRepository.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/data/repository/MemoRepository.kt
@@ -5,39 +5,79 @@ import android.net.Uri
 import com.example.simplememoapp_android.data.local.dao.MemoDao
 import com.example.simplememoapp_android.data.model.Memo
 import com.example.simplememoapp_android.data.model.SerializableMemo
+import com.example.simplememoapp_android.network.ApiService
+import com.example.simplememoapp_android.network.dto.MemoRequest
+import com.example.simplememoapp_android.network.dto.toEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class MemoRepository(private val memoDao: MemoDao) {
-
-    // メモ全件をFlowとして取得する
-    fun getMemos(): Flow<List<Memo>> = memoDao.getAllMemos()
-
-    // IDを指定して単一のメモをFlowとして取得する
-    fun getMemoById(id: Long): Flow<Memo> = memoDao.getMemoById(id)
-
-    // メモを新規追加する
-    suspend fun addMemo(memo: Memo) {
-        memoDao.insertMemo(memo)
+@Singleton
+class MemoRepository @Inject constructor(
+    private val memoDao: MemoDao,
+    private val apiService: ApiService,
+    private val userRepository: UserRepository
+) {
+    val memos: Flow<List<Memo>> = userRepository.loggedInUserIdFlow.flatMapLatest { userId ->
+        if (userId.isNullOrBlank()) {
+            flowOf(emptyList())
+        } else {
+            memoDao.getMemosByUserId(userId)
+        }
     }
 
-    // メモを更新する
-    suspend fun updateMemo(memo: Memo) {
-        memoDao.updateMemo(memo)
+    suspend fun refreshMemos() {
+        val userId = userRepository.loggedInUserIdFlow.first()
+        if (userId.isNullOrBlank()) return
+
+        try {
+            val remoteMemos = apiService.getMemosForUser(userId)
+            memoDao.deleteAllByUserId(userId)
+            memoDao.insertAll(remoteMemos.map { it.toEntity() })
+        } catch (e: Exception) {
+            // TODO: エラーをUIに通知する仕組み
+        }
     }
 
-    // メモを削除する
+    suspend fun addMemo(title: String, content: String) {
+        val userId = userRepository.loggedInUserIdFlow.first() ?: return
+        val request = MemoRequest(title, content, userId)
+        val newMemoFromApi = apiService.createMemo(userId, request)
+        memoDao.insertMemo(newMemoFromApi.toEntity())
+    }
+
+    suspend fun updateMemo(memo: Memo, title: String, content: String) {
+        val request = MemoRequest(title, content, memo.userId)
+        val updatedMemoFromApi = apiService.updateMemo(memo.userId, memo.serverId, request)
+        memoDao.updateMemo(updatedMemoFromApi.toEntity())
+    }
+
     suspend fun deleteMemo(memo: Memo) {
+        apiService.deleteMemo(memo.userId, memo.serverId)
         memoDao.deleteMemo(memo)
     }
 
     suspend fun exportMemosToFile(uri: Uri, contentResolver: ContentResolver) {
         withContext(Dispatchers.IO) {
-            val memos = memoDao.getAllMemos().first()
+            // ★★★ ここから修正 ★★★
+            // 1. 現在ログインしているユーザーのIDを取得
+            val userId = userRepository.loggedInUserIdFlow.first()
+            if (userId.isNullOrBlank()) {
+                // ログインしていない場合はエクスポートしない
+                return@withContext
+            }
+
+            // 2. そのユーザーのメモだけをDBから取得
+            val memos = memoDao.getMemosByUserId(userId).first()
+            // ★★★ ここまで修正 ★★★
+
             val serializableMemos = memos.map { memo ->
                 SerializableMemo(
                     title = memo.title,
@@ -52,4 +92,5 @@ class MemoRepository(private val memoDao: MemoDao) {
             }
         }
     }
+
 }

--- a/app/src/main/java/com/example/simplememoapp_android/di/AppModule.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/di/AppModule.kt
@@ -7,8 +7,8 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.room.Room
 import com.example.simplememoapp_android.data.local.AppDatabase
+import com.example.simplememoapp_android.data.local.AppDatabase.Companion.MIGRATION_2_3
 import com.example.simplememoapp_android.data.local.dao.MemoDao
-import com.example.simplememoapp_android.data.repository.MemoRepository
 import com.example.simplememoapp_android.network.ApiService
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
@@ -36,7 +36,7 @@ object AppModule {
             AppDatabase::class.java,
             "memo_database"
         )
-            .addMigrations(AppDatabase.MIGRATION_1_2)
+            .addMigrations(AppDatabase.MIGRATION_1_2, MIGRATION_2_3)
             .build()
     }
 
@@ -46,13 +46,10 @@ object AppModule {
         return db.memoDao()
     }
 
-    @Provides
-    @Singleton
-    fun provideMemoRepository(dao: MemoDao): MemoRepository {
-        return MemoRepository(dao)
-    }
+    // この関数は不要なので削除しました。
+    // MemoRepositoryには @Inject constructor が付いているため、
+    // Hiltが自動でインスタンスの生成方法を見つけてくれます。
 
-    // ★★★ 以下を追記 ★★★
     @Provides
     @Singleton
     fun provideOkHttpClient(): OkHttpClient {

--- a/app/src/main/java/com/example/simplememoapp_android/network/ApiService.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/network/ApiService.kt
@@ -1,22 +1,35 @@
 package com.example.simplememoapp_android.network
 
+import com.example.simplememoapp_android.network.dto.MemoRequest
 import com.example.simplememoapp_android.network.dto.MemoResponse
 import com.example.simplememoapp_android.network.dto.UserRequest
 import com.example.simplememoapp_android.network.dto.UserResponse
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface ApiService {
-    @GET("user/{userId}/memo")
-    suspend fun getMemosForUser(@Path("userId") userId: String): List<MemoResponse>
-
+    // --- User Endpoints ---
     @GET("user")
     suspend fun getUserByEmail(@Query("email") email: String): List<UserResponse>
 
     @POST("user")
     suspend fun registerUser(@Body user: UserRequest): UserResponse
 
+    // --- Memo Endpoints ---
+    @GET("users/{userId}/memos")
+    suspend fun getMemosForUser(@Path("userId") userId: String): List<MemoResponse>
+
+    @POST("users/{userId}/memos")
+    suspend fun createMemo(@Path("userId") userId: String, @Body memo: MemoRequest): MemoResponse
+
+    @PUT("users/{userId}/memos/{memoId}")
+    suspend fun updateMemo(@Path("userId") userId: String, @Path("memoId") memoId: String, @Body memo: MemoRequest): MemoResponse
+
+    @DELETE("users/{userId}/memos/{memoId}")
+    suspend fun deleteMemo(@Path("userId") userId: String, @Path("memoId") memoId: String): MemoResponse
 }

--- a/app/src/main/java/com/example/simplememoapp_android/network/dto/MemoRequest.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/network/dto/MemoRequest.kt
@@ -1,0 +1,12 @@
+// network/dto/MemoRequest.kt (新規作成)
+package com.example.simplememoapp_android.network.dto
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.Serializable
+
+@OptIn(InternalSerializationApi::class)
+@Serializable
+data class MemoRequest(
+    val title: String,
+    val content: String,
+    val userId: String
+)

--- a/app/src/main/java/com/example/simplememoapp_android/network/dto/MemoResponse.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/network/dto/MemoResponse.kt
@@ -1,7 +1,11 @@
 package com.example.simplememoapp_android.network.dto
 
+import com.example.simplememoapp_android.data.model.Memo
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 @OptIn(InternalSerializationApi::class)
 @Serializable
@@ -10,6 +14,22 @@ data class MemoResponse(
     val createdAt: Long,
     val title: String,
     val content: String,
-    val updateAt: Long,
+    val updatedAt: Long, // フィールド名を 'updateAt' から 'updatedAt' に修正
     val userId: String
 )
+
+// DTOからEntityへの変換関数
+fun MemoResponse.toEntity(): Memo {
+    // Long型（Unixタイムスタンプ/epoch seconds）をLocalDateTimeに変換します
+    val createdAtDateTime = LocalDateTime.ofInstant(Instant.ofEpochSecond(this.createdAt), ZoneId.systemDefault())
+    val updatedAtDateTime = LocalDateTime.ofInstant(Instant.ofEpochSecond(this.updatedAt), ZoneId.systemDefault())
+
+    return Memo(
+        serverId = this.id,
+        userId = this.userId,
+        title = this.title,
+        content = this.content,
+        createdAt = createdAtDateTime,
+        updatedAt = updatedAtDateTime
+    )
+}

--- a/app/src/main/java/com/example/simplememoapp_android/ui/screen/MemoDetailScreen.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/ui/screen/MemoDetailScreen.kt
@@ -40,6 +40,10 @@ fun MemoDetailScreen(
                 is UiEvent.ShowSnackbar -> {
                     snackbarHostState.showSnackbar(message = event.message)
                 }
+                // ★★★ このelse分岐を追加して、when式を網羅的にする ★★★
+                else -> {
+                    // この画面ではSnackbar以外のイベントは処理しない
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/simplememoapp_android/ui/screen/MemoListScreen.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/ui/screen/MemoListScreen.kt
@@ -75,6 +75,9 @@ fun MemoListScreen(navController: NavController) {
                         message = event.message
                     )
                 }
+                else -> {
+                    // MemoListScreenでは他のイベントは処理しない
+                }
             }
         }
     }
@@ -151,12 +154,12 @@ fun MemoListScreen(navController: NavController) {
                     MemoListSection(
                         memos = state.memos,
                         // ここで onDeleteClick の実処理 (ViewModelのメソッド呼び出し) を渡す
-                        onDeleteClick = { memo ->
-                            viewModel.deleteMemo(memo)
+                        onDeleteClick = {
+                            viewModel.deleteMemo(it)
                         },
                         // ★ メモアイテムをタップしたときの処理を追加
                         onMemoClick = { memo ->
-                            navController.navigate("memo_detail/${memo.id}")
+                                navController.navigate("memo_detail/${memo.id}")
                         }
                     )
                 }
@@ -202,6 +205,8 @@ fun PreviewMemoListSection() {
         val dummyMemos = listOf(
             Memo(
                 id = 1,
+                serverId = "server1",
+                userId = "user1",
                 title = "キックボクシング",
                 content = "キックボクシングに行く",
                 createdAt = LocalDateTime.now(),
@@ -209,6 +214,8 @@ fun PreviewMemoListSection() {
             ),
             Memo(
                 id = 2,
+                serverId = "server2",
+                userId = "user1",
                 title = "タリーズ",
                 content = "タリーズで実装する",
                 createdAt = LocalDateTime.now(),
@@ -216,6 +223,8 @@ fun PreviewMemoListSection() {
             ),
             Memo(
                 id = 3,
+                serverId = "server3",
+                userId = "user1",
                 title = "筋トレ",
                 content = "夜はジムで筋トレ",
                 createdAt = LocalDateTime.now(),
@@ -274,6 +283,8 @@ fun PreviewMemoItem() {
     MemoItem(
         memo = Memo(
             id = 1, // プレビュー用に適当なID
+            serverId = "server1",
+            userId = "user1",
             title = "プレビュー用のメモ",
             content = "これはプレビュー用のメモです！",
             createdAt = LocalDateTime.now(),
@@ -295,4 +306,3 @@ fun MemoListScreenPreview() {
     // Previewでは実際のナビゲーションは不要なので、ダミーのNavControllerを渡す
     MemoListScreen(navController = rememberNavController())
 }
-

--- a/app/src/main/java/com/example/simplememoapp_android/ui/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/simplememoapp_android/ui/viewmodel/AuthViewModel.kt
@@ -19,7 +19,7 @@ data class AuthUiState(
 )
 
 sealed interface AuthUiEvent {
-    data class NavigateTo(val route: String) : AuthUiEvent
+    data class NavigateTo(val route: String) : AuthUiEvent, UiEvent
     data class ShowSnackbar(val message: String) : AuthUiEvent
 }
 


### PR DESCRIPTION
This commit introduces server synchronization capabilities for memos, enabling full CRUD (Create, Read, Update, Delete) operations with a remote API. It also refactors the data layer to support multi-user functionality.